### PR TITLE
Fixed plan visibility when turning off test mode

### DIFF
--- a/app/views/branded/plans/_edit_details.html.erb
+++ b/app/views/branded/plans/_edit_details.html.erb
@@ -10,6 +10,7 @@
             title: _('If applying for funding, state the name exactly as in the grant proposal.')) %>
       <div class="checkbox">
         <%= f.hidden_field :visibility %>
+        <%= f.hidden_field :default_visibility, value: Rails.configuration.default_plan_visibility %>
         <%= f.label(:is_test, raw("#{check_box_tag(:is_test,1, @plan.is_test? , "aria-label": "is_test")} #{_('mock project for testing, practice, or educational purposes')}"), class: 'control-label') %>
       </div>
         </div>

--- a/lib/assets/javascripts/views/plans/edit_details.js
+++ b/lib/assets/javascripts/views/plans/edit_details.js
@@ -5,7 +5,8 @@ import getConstant from '../../constants';
 $(() => {
   Tinymce.init();
   $('#is_test').click((e) => {
-    $('#plan_visibility').val($(e.target).is(':checked') ? 'is_test' : 'privately_visible');
+    const DefaultVisibility = $('#plan_default_visibility').val();
+    $('#plan_visibility').val($(e.target).is(':checked') ? 'is_test' : DefaultVisibility);
   });
   ariatiseForm({ selector: '.edit_plan' });
 
@@ -78,4 +79,3 @@ $(() => {
 
   toggleCheckboxes($('#priority-guidance-orgs input[type="checkbox"]:checked').map((i, el) => $(el).val()).get());
 });
-


### PR DESCRIPTION
Fixes #93 .

**CHANGELOG**
- Unchecking the "is_test" box on a plan now sets its visibility to the default value set in *application.rb*