### PR TITLE
Implement Loterre API calls

### DIFF
--- a/engines/madmp_opidor/app/controllers/api/v1/madmp/services_controller.rb
+++ b/engines/madmp_opidor/app/controllers/api/v1/madmp/services_controller.rb
@@ -7,7 +7,7 @@ module Api
     module Madmp
       # Handles CRUD operations for Services in API V1
       class ServicesController < BaseApiController
-        before_action :authorize_request, except: %i[ror orcid]
+        before_action :authorize_request, except: %i[ror orcid loterre]
 
         respond_to :json
 
@@ -25,6 +25,16 @@ module Api
           render json: MadmpExternalApis::OrcidService.search(
             term: params[:search],
             rows: params[:rows]
+          )
+        end
+
+        # GET /api/v1/madmp/services/loterre/{endpoint}[query_parameters]
+        # :endpoint Loterre endpoint
+        # :params query parameters
+        def loterre
+          render json: MadmpExternalApis::LoterreService.request(
+            query_params: request.query_parameters,
+            params:
           )
         end
       end

--- a/engines/madmp_opidor/app/services/madmp_external_apis/loterre_service.rb
+++ b/engines/madmp_opidor/app/services/madmp_external_apis/loterre_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'cgi'
+require 'uri'
+
+module MadmpExternalApis
+  # This service provides an interface to Loterre API
+  class LoterreService < ::ExternalApis::BaseService
+    class << self
+      # Retrieve the config settings from the initializer
+      def landing_page_url
+        Rails.configuration.x.loterre&.landing_page_url || super
+      end
+
+      def api_base_url
+        Rails.configuration.x.loterre&.api_base_url || super
+      end
+
+      def active?
+        Rails.configuration.x.loterre&.active || super
+      end
+
+      def endpoints
+        Rails.configuration.x.loterre&.endpoints
+      end
+
+      # Ping the Loterre API to determine if it is online
+      #
+      # @return true/false
+      def ping
+        return true unless active?
+
+        resp = http_get(uri: api_base_url)
+        resp.present? && resp.code == 200
+      end
+
+      # Use Loterre API
+      def request(query_params: {}, params: {})
+        return [] unless active?
+
+        target = "#{api_base_url}/#{params&.dig(:path)}?#{URI.encode_www_form(query_params)}"
+
+        resp = http_get(
+          uri: target,
+          additional_headers: {}
+        )
+
+        handle_failure(resp) unless resp.present? && [200, 201].include?(resp.code)
+
+        resp
+      end
+
+      def handle_failure(resp)
+        handle_http_failure(method: 'LoterreService query_builder', http_response: resp)
+        nil
+      end
+    end
+  end
+end

--- a/engines/madmp_opidor/config/initializers/external_apis/loterre.rb
+++ b/engines/madmp_opidor/config/initializers/external_apis/loterre.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.configuration.x.loterre.landing_page_url = 'https://www.loterre.fr/'
+Rails.configuration.x.loterre.api_base_url = 'https://skosmos.loterre.fr/rest/v1'
+Rails.configuration.x.loterre.active = true

--- a/engines/madmp_opidor/config/routes.rb
+++ b/engines/madmp_opidor/config/routes.rb
@@ -57,6 +57,9 @@ Rails.application.routes.draw do
           resources :items, only: %i[ror orcid]
           get 'ror', action: :ror, on: :collection, as: :ror
           get 'orcid', action: :orcid, on: :collection, as: :orcid
+          # get 'loterre/:endpoint', action: :loterre, on: :collection, as: :loterre
+          # get 'loterre/:vocid/(:endpoint)', action: :loterre_with_vocid, on: :collection, as: :loterre_with_vocid
+          get 'loterre/*path', action: :loterre, on: :collection, as: :loterre
         end
       end
     end


### PR DESCRIPTION
Loterre API implementation, documentation here: [https://www.loterre.fr/api-1/](https://www.loterre.fr/api-1/)

Calls are made to the DMPOPIDOR API via this route ``/api/v1/madmp/services/loterre/{endpoint}[query_parameters]``, ``endpoint`` corresponds to Loterre API endpoints (or routes) and ``query_parameters`` corresponds to Loterre route parameters.

For example: 
+ ``/api/v1/madmp/services/loterre/vocabularies?lang=en``
+ ``/api/v1/madmp/services/loterre//yso/search?query=cat``