### PR TITLE
Fix/various fixes

### DIFF
--- a/CHANGELOG_DMPOPIDoR_V4.md
+++ b/CHANGELOG_DMPOPIDoR_V4.md
@@ -2,15 +2,19 @@
 
 **Attention** Cette liste de changements concerne les déploiements sur nos serveurs de test en interne.
 
+- Modification du style par défaut des modales (``InnerModal``) des commentaires, recommendations, ...
+- Changement affichage bouton "choix du formulaire personnalisé", il s'affiche comme les commentaires, recommendations, ...
+- Correction affichage nombre de commentaire (titre de la modale)
+- Retrait des modèles Entité de la liste des modèles proposés lors de l'import de plan
+- Correction d'un problème de mise à jour de l'infobox des produits de recherche lors de l'import d'un plan (#10340)
+- Ajout de l'identifiant d'affiliation clickable dans la liste des contributeurs de l'onglet Contributeurs et de l'export de Plan (#10295)
+
 ## 05/03/2024
 
 - Ajout du support de l'option 'overridable' pour le rôle des contributeurs
 - Ajustement de la position du tooltip permissions de l'onglet Partager (#10330)
 - Correction d'un problème d'import de plan au format JSON (#10318)
 - Changement de l'attribut ``disable`` des ``input`` de type ``text`` pour ``readonly`` ce qui permet de sauvegarder les valeurs **constantes**
-- Modification du style par défaut des modales (``InnerModal``) des commentaires, recommendations, ...
-- Changement affichage bouton "choix du formulaire personnalisé", il s'affiche comme les commentaires, recommendations, ...
-- Correction affichage nombre de commentaire (titre de la modale)
 
 ## 04/03/2024
 

--- a/app/controllers/dmpopidor/plans_controller.rb
+++ b/app/controllers/dmpopidor/plans_controller.rb
@@ -310,7 +310,7 @@ module Dmpopidor
       authorize @plan
 
       @templates = ::Template.includes(:org)
-                             .where(type: 'structured', customization_of: nil)
+                             .where(type: 'structured', context: 'research_project', customization_of: nil)
                              .unarchived.published
     end
 

--- a/app/views/branded/shared/export/_plan_coversheet.erb
+++ b/app/views/branded/shared/export/_plan_coversheet.erb
@@ -74,6 +74,7 @@
       <tbody>
       <% contributors.each do |contributor| %>
         <% person_id = contributor.data["personId"]%>
+        <% affiliation_id = contributor.data["affiliationId"]%>
         <tr>
           <td>
             <%= contributor.to_s %>
@@ -81,7 +82,12 @@
               - <%= uri?(person_id) ? link_to(person_id, person_id, target: "_blank") : person_id %>
             <% end %>
           </td>
-          <td><%= contributor.data["affiliationName"] %></td>
+          <td>
+            <%= contributor.data["affiliationName"] %>
+            <% if affiliation_id.present? %>
+              - <%= uri?(affiliation_id) ? link_to(affiliation_id, affiliation_id, target: "_blank") : affiliation_id %>
+            <% end %>
+          </td>
           <td>
             <% if contributor.roles.present? %>
               <ul>

--- a/engines/madmp_opidor/app/services/import/plan_import_service.rb
+++ b/engines/madmp_opidor/app/services/import/plan_import_service.rb
@@ -33,6 +33,7 @@ module Import
             research_output.create_json_fragments
             ro_frag = research_output.json_fragment
             import_research_output(ro_frag, ro_data, plan)
+            ro_frag.research_output_description.update_research_output_parameters(true)
           end
         end
       end


### PR DESCRIPTION

- Retrait des modèles Entité de la liste des modèles proposés lors de l'import de plan
- Correction d'un problème de mise à jour de l'infobox des produits de recherche lors de l'import d'un plan (#10340)
- Ajout de l'identifiant d'affiliation clickable dans la liste des contributeurs de l'onglet Contributeurs et de l'export de Plan (#10295)