### PR TITLE
Fix/preprod issues

### DIFF
--- a/CHANGELOG_DMPOPIDoR_V4.md
+++ b/CHANGELOG_DMPOPIDoR_V4.md
@@ -2,6 +2,13 @@
 
 **Attention** Cette liste de changements concerne les déploiements sur nos serveurs de test en interne.
 
+## 25/03/2024
+
+- Correction d'un problème d'export PDF/DOCX des plans entité
+- Correction d'un problème d'enregistrement des champs texte multiples (mots clés non controlés)
+- Les plans du tableau de bord sont marqués comme Partagé quand un client a accès au plan.
+- La zone Services Externes est désormais ouverte quand un client a accès au plan
+
 ## 21/03/2024
 
 - Corrections de textes diverses

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -677,7 +677,7 @@ class Plan < ApplicationRecord
   #
   # Returns Boolean
   def shared?
-    roles.select(&:active).reject(&:creator).any?
+    roles.select(&:active).reject(&:creator).any? || api_client_roles.reject(&:creator).any?
   end
 
   alias shared shared?

--- a/app/views/branded/plans/_share_third_party.html.erb
+++ b/app/views/branded/plans/_share_third_party.html.erb
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div id="api_client_roles" class="panel-collapse collapse plan-details-content" role="tabpanel" aria-labelledby="heading-api-client-roles">
+<div id="api_client_roles" class="panel-collapse collapse <%= 'in' if @plan_client_roles.any? %> plan-details-content" role="tabpanel" aria-labelledby="heading-api-client-roles">
   <div class="panel-body">
     <p><%= _('An "external service" can be provided by an organisation, a platform or a data infrastructure. These services are allowed (by DMP OPIDoR team) to automatically collect information that is being captured in data management plan, once you have given them the authorization, in order to offer you some services.') %></p>
     <% if @plan_client_roles.any? then %>

--- a/engines/madmp_opidor/app/models/fragment/person.rb
+++ b/engines/madmp_opidor/app/models/fragment/person.rb
@@ -21,7 +21,7 @@
 module Fragment
   # Budget STI model
   class Person < MadmpFragment
-    NON_RO_CLASSES = %w[meta project].freeze
+    NON_RO_CLASSES = %w[meta project research_entity].freeze
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def roles(selected_research_outputs = nil)


### PR DESCRIPTION
- Correction d'un problème d'export PDF/DOCX des plans entité
- Correction d'un problème d'enregistrement des champs texte multiples (mots clés non controlés)
- Les plans du tableau de bord sont marqués comme Partagé quand un client a accès au plan.
- La zone Services Externes est désormais ouverte quand un client a accès au plan