### PR TITLE
Added Module template

### DIFF
--- a/CHANGELOG_DMPOPIDoR.md
+++ b/CHANGELOG_DMPOPIDoR.md
@@ -2,23 +2,20 @@
 
 **Attention** Cette liste de changements concerne les déploiements sur nos serveurs de test en interne.
 
-# 18/04/2024
+### Modification de la création/ajout des modèles de DMP
 
-- Correction du problème de suppression des valeurs dans les référentiels simples à choix multiples, ex: DocumentationQualityStandard.documentationSoftware (#10831)
-- Augmentation du nombre de caractères (100 caractères) des titres des DMP affichés en visibilité Privé, Organisme & Administrateur
-- Augmentation de la durée de la session de connexion de 90 minutes à 24h.
+- Le bouton Créer un modèle permet de créer un modèle structuré
+- Ajout d'un bouton Créer un modèle classique
+- Le type de modèle n'est plus modifiable
+- Le contexte du modèle n'est plus modifiable après sa création
+- Les modèles structurés ne peuvent désormais avoir qu'une seule phase
 
-# 16/04/2024
+### Ajout d'un nouveau type de modèle de DMP, appelé Module.
 
-- Correction du problème d'affichage de l'onglet Informations Générales
-- Correction du problème de copie des plans classiques (#10815)
-- Export PDF/DOCX : Ajout d'une vérification du format des données utilisées lors de l'affichage d'un tableau de chaines de caractère (problème d'affichage de documentationSoftware dans DocumentationQualityStandard suite à une incompatibilité entre les schemas V3 et V4) (#10818)
-- Mise à jour de TinyMCE (éditeur de texte)
+Un module est un modèle ne comportant qu'une phase. On ne peut pas créer de plan à partir d'un module mais un plan peut utiliser les sections et les questions du module en fonction des paramètres d'un de ses produits de recherche.
 
-# 12/04/2024
-
-- Désactivation de la création d'organisme depuis RoR dans la création de compte (#10798)
-- Les liens des pages statiques sont désormais soulignés (#10797)
-- Ajout du mode lecture seule dans l'onglet contributeurs (#10800)
-- Correction du problème d'affichage des icones Commentaires/Recommandations (#10794)
-- Correction du démarrage automatique de la visite guidée, attente du rendu des composants de la page avant de la lancer.
+- Ajout d'un champ data_type permettant de définir le type de produit de recherche utilisant ce module.
+- Ajout du champ data_type à madmp_schemas
+- On ne peut pas créer de phase (une seule présente)
+- L'ajout de questions et de sections est identique à l'existant
+- Les formulaires proposés dans l'ajout d'une question sont ceux qui concernent le data_type du modèle.

--- a/app/controllers/dmpopidor/org_admin/questions_controller.rb
+++ b/app/controllers/dmpopidor/org_admin/questions_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Dmpopidor
+  module OrgAdmin
+    # Customized code for OrgAdmin QuestionsController
+    module QuestionsController
+      # GET /org_admin/templates/[:template_id]/phases/[:phase_id]/sections/[:id]/questions/[:question_id]/edit
+      # rubocop:disable Metrics/MethodLength
+      # CHANGES : Added  MadmpSchema list
+      def edit
+        question = Question.includes(:annotations,
+                                    :question_options,
+                                    section: { phase: :template })
+                          .find(params[:id])
+        template = question.section.phase.template
+        @available_classnames = Settings::Question::AVAILABLE_CLASSNAMES[template.data_type]
+        @madmp_schemas = MadmpSchema.where(classname: @available_classnames, data_type: template.data_type)
+        authorize question
+        render json: { html: render_to_string(partial: 'edit', locals: {
+                                                template: template,
+                                                section: question.section,
+                                                question: question,
+                                                question_formats: allowed_question_formats,
+                                                conditions: question.conditions
+                                              }) }
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # SEE MODULE
+      # GET /org_admin/templates/:template_id/phases/:phase_id/sections/:section_id/questions/new
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # CHANGES : Added  MadmpSchema list
+      def new
+        section = Section.includes(:questions, phase: :template).find(params[:section_id])
+        template = section.phase.template
+        nbr = section.questions.maximum(:number)
+        question_format = QuestionFormat.find_by(title: 'Text area')
+        question = Question.new(section_id: section.id,
+                                question_format: question_format,
+                                number: nbr.present? ? nbr + 1 : 1)
+        question_formats = allowed_question_formats
+        @available_classnames = Settings::Question::AVAILABLE_CLASSNAMES[template.data_type]
+        p "####################"
+        p Settings::Question::AVAILABLE_CLASSNAMES
+        p "####################"
+        @madmp_schemas = MadmpSchema.where(classname: @available_classnames, data_type: template.data_type)
+        authorize question
+        render json: { html: render_to_string(partial: 'form', locals: {
+                                                template: template,
+                                                section: section,
+                                                question: question,
+                                                method: 'post',
+                                                url: org_admin_template_phase_section_questions_path(
+                                                  template_id: template.id,
+                                                  phase_id: section.phase.id,
+                                                  id: section.id
+                                                ),
+                                                question_formats: question_formats
+                                              }) }
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    end
+  end
+end

--- a/app/controllers/dmpopidor/org_admin/questions_controller.rb
+++ b/app/controllers/dmpopidor/org_admin/questions_controller.rb
@@ -40,9 +40,7 @@ module Dmpopidor
                                 number: nbr.present? ? nbr + 1 : 1)
         question_formats = allowed_question_formats
         @available_classnames = Settings::Question::AVAILABLE_CLASSNAMES[template.data_type]
-        p "####################"
-        p Settings::Question::AVAILABLE_CLASSNAMES
-        p "####################"
+
         @madmp_schemas = MadmpSchema.where(classname: @available_classnames, data_type: template.data_type)
         authorize question
         render json: { html: render_to_string(partial: 'form', locals: {

--- a/app/controllers/dmpopidor/orgs_controller.rb
+++ b/app/controllers/dmpopidor/orgs_controller.rb
@@ -15,7 +15,8 @@ module Dmpopidor
                                     archived: false,
                                     is_recommended: false,
                                     context: params[:context],
-                                    locale: params[:locale]  
+                                    locale: params[:locale] ,
+                                    type: ['classic', 'structured']
                                   }
                                )
       @orgs = if params[:type] == 'org'

--- a/app/controllers/dmpopidor/template_options_controller.rb
+++ b/app/controllers/dmpopidor/template_options_controller.rb
@@ -45,12 +45,20 @@ module Dmpopidor
         # If the no funder was specified OR the funder matches the org
         if funder.blank? || funder.id == org&.id
           # Retrieve the Org's templates
-          @templates << ::Template.published.where(org_id: org&.id, context: template_context).to_a
+          @templates << ::Template.published.where(
+            org_id: org&.id,
+            context: template_context,
+            type: ['classic', 'structured']
+          ).to_a
         end
 
       else
         @templates = ::Template.published
-                               .where(org_id: current_user.org.id, context: template_context).to_a
+                               .where(
+                                  org_id: current_user.org.id,
+                                  context: template_context,
+                                  type: ['classic', 'structured']
+                                ).to_a
       end
 
       @templates = @templates.flatten.uniq

--- a/app/controllers/org_admin/questions_controller.rb
+++ b/app/controllers/org_admin/questions_controller.rb
@@ -6,6 +6,7 @@ module OrgAdmin
     include AllowedQuestionFormats
     include Versionable
     include ConditionsHelper
+    prepend Dmpopidor::OrgAdmin::QuestionsController
 
     respond_to :html
     after_action :verify_authorized
@@ -48,28 +49,7 @@ module OrgAdmin
                                    section: { phase: :template })
                          .find(params[:id])
 
-      # --------------------------------
-      # Start DMP OPIDoR Customization
-      # CHANGES : Added  MadmpSchema list
-      # --------------------------------
-      @available_classnames = %w[
-        research_output_description
-        data_reuse
-        personal_data_issues
-        legal_issues
-        ethical_issues
-        data_collection
-        data_processing
-        data_storage
-        documentation_quality
-        quality_assurance_method
-        data_sharing
-        data_preservation
-      ]
-      @madmp_schemas = MadmpSchema.where(classname: @available_classnames)
-      # --------------------------------
-      # End DMP OPIDoR Customization
-      # --------------------------------
+
       authorize question
       render json: { html: render_to_string(partial: 'edit', locals: {
                                               template: question.section.phase.template,
@@ -92,28 +72,7 @@ module OrgAdmin
                               question_format: question_format,
                               number: nbr.present? ? nbr + 1 : 1)
       question_formats = allowed_question_formats
-      # --------------------------------
-      # Start DMP OPIDoR Customization
-      # CHANGES : Added  MadmpSchema list
-      # --------------------------------
-      @available_classnames = %w[
-        research_output_description
-        data_reuse
-        personal_data_issues
-        legal_issues
-        ethical_issues
-        data_collection
-        data_processing
-        data_storage
-        documentation_quality
-        quality_assurance_method
-        data_sharing
-        data_preservation
-      ]
-      @madmp_schemas = MadmpSchema.where(classname: @available_classnames)
-      # --------------------------------
-      # End DMP OPIDoR Customization
-      # --------------------------------
+
       authorize question
       render json: { html: render_to_string(partial: 'form', locals: {
                                               template: section.phase.template,

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -401,9 +401,9 @@ module OrgAdmin
       # the template: :links context.
       # --------------------------------
       # Start DMP OPIDoR Customization
-      # CHANGES : Added Locale, Type & Context
+      # CHANGES : Added Locale, Type, Context & DataType
       # --------------------------------
-      params.require(:template).permit(:title, :description, :visibility, :links, :locale, :type, :context)
+      params.require(:template).permit(:title, :description, :visibility, :links, :locale, :type, :context, :data_type)
       # --------------------------------
       # End DMP OPIDoR Customization
       # --------------------------------

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -166,11 +166,12 @@ module OrgAdmin
     # SEE MODULE
     def new
       authorize Template
-      @template = current_org.templates.new
       # --------------------------------
       # Start DMP OPIDoR Customization
       # CHANGES : Added Locales list
+      # CHANGES : Added Type param
       # --------------------------------
+      @template = current_org.templates.new(type: params[:type])
       @locales = Language.all
       # --------------------------------
       # End DMP OPIDoR Customization

--- a/app/helpers/template_helper.rb
+++ b/app/helpers/template_helper.rb
@@ -56,4 +56,15 @@ module TemplateHelper
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # rubocop:enable Style/OptionalBooleanParameter
+
+  # Method that determines if an admin can add a phase to a template
+  # Returns true for classic templates
+  # Returns true for structured & module templates if there is no phase
+  def can_add_phase?(template)
+    return true if template.classic?
+
+    return true if template.phases.length == 0
+
+  end
+
 end

--- a/app/models/settings/question.rb
+++ b/app/models/settings/question.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: settings
+#
+#  id          :integer          not null, primary key
+#  target_type :string           not null
+#  value       :text
+#  var         :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  target_id   :integer          not null
+#
+# Indexes
+#
+#  settings_target_type_target_id_var_key  (target_type,target_id,var) UNIQUE
+#
+
+module Settings
+  # Settings the questions
+  class Question < RailsSettings::SettingObject
+    AVAILABLE_CLASSNAMES = {
+      "none" => %w[
+        research_output_description
+        data_reuse
+        personal_data_issues
+        legal_issues
+        ethical_issues
+        data_collection
+        data_processing
+        data_storage
+        documentation_quality
+        quality_assurance_method
+        data_sharing
+        data_preservation
+      ],
+      "software" => %w[
+        software_description
+      ]
+    }.freeze
+  end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -39,13 +39,6 @@
 class Template < ApplicationRecord
   include GlobalHelpers
   extend UniqueRandom
-  # --------------------------------
-  # Start DMP OPIDoR Customization
-  # --------------------------------
-  # prepend Dmpopidor::Template
-  # --------------------------------
-  # End DMP OPIDoR Customization
-  # --------------------------------
 
   validates_with TemplateLinksValidator
 
@@ -58,12 +51,13 @@ class Template < ApplicationRecord
   # --------------------------------
   # Start DMP OPIDoR Customization
   # --------------------------------
-  # A standard template will have access to question types such as text, textarea
+  # A classic template will have access to question types such as text, textarea
   # date, number ...
   # For structured templates, question types will be restricted to structured, with
   # access to structured forms when adding a new question.
+  # Module templates can only have one phase, have a data_type & can't be used by a plan
   self.inheritance_column = nil
-  enum type: %i[classic structured]
+  enum type: %i[classic structured module]
   # Context describes if the DMP is for a Research Project ou a Research Entity
   # The Project Form is replaced by a Structure Form in the General information tab.
   # New features might be added in the future

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -252,7 +252,7 @@ class Template < ApplicationRecord
   end
 
   def self.recommend(context: 'research_project', locale: 'fr-FR')
-    where(is_recommended: true, published: true, context: , locale:).last
+    where(is_recommended: true, published: true, type: 'structured', context: , locale:).last
   end
 
   def self.current(family_id)

--- a/app/views/branded/org_admin/questions/_form.html.erb
+++ b/app/views/branded/org_admin/questions/_form.html.erb
@@ -23,7 +23,23 @@
       <%= f.text_area(:text, class: "question", spellcheck: true, "aria-required": true) %>
     </div>
 
-    <% if template.structured? %>
+    <% if template.classic? %>
+      <!-- Question format -->
+      <div class="form-group col-md-4">
+        <%= f.label(:question_format_id, _('Answer format'), class: "control-label") %>
+          <%= f.select :question_format_id,
+            options_from_collection_for_select(question_formats,
+            :id,
+            :title,
+            question.question_format_id),
+            {},
+            class: "form-control question_format",
+            'data-toggle': 'tooltip',
+            'data-html': true,
+            title: _("You can choose from:<ul><li>- text area (large box for paragraphs);</li> <li>- text field (for a short answer);</li> <li>- checkboxes where options are presented in a list and multiple values can be selected;</li> <li>- radio buttons where options are presented in a list but only one can be selected;</li> <li>- dropdown like this box - only one option can be selected;</li> <li>- multiple select box allows users to select several options from a scrollable list, using the CTRL key;</li></ul>")
+          %>
+      </div>
+    <% else %>
       <%= f.hidden_field :question_format_id, value: QuestionFormat.id_for("structured")%>
       <!-- Structured Data Schemas -->
       <div class="form-group col-md-10">
@@ -48,22 +64,6 @@
             {},
             class: "form-control question_schema"
         %>
-      </div>
-    <% else %>
-      <!-- Question format -->
-      <div class="form-group col-md-4">
-        <%= f.label(:question_format_id, _('Answer format'), class: "control-label") %>
-          <%= f.select :question_format_id,
-            options_from_collection_for_select(question_formats,
-            :id,
-            :title,
-            question.question_format_id),
-            {},
-            class: "form-control question_format",
-            'data-toggle': 'tooltip',
-            'data-html': true,
-            title: _("You can choose from:<ul><li>- text area (large box for paragraphs);</li> <li>- text field (for a short answer);</li> <li>- checkboxes where options are presented in a list and multiple values can be selected;</li> <li>- radio buttons where options are presented in a list but only one can be selected;</li> <li>- dropdown like this box - only one option can be selected;</li> <li>- multiple select box allows users to select several options from a scrollable list, using the CTRL key;</li></ul>")
-          %>
       </div>
     <% end %>
 

--- a/app/views/branded/org_admin/templates/_form.html.erb
+++ b/app/views/branded/org_admin/templates/_form.html.erb
@@ -39,13 +39,16 @@
 
 <div class="form-group col-xs-8">
   <%= f.label(:type, _('Type'), class: "control-label") %>
-    <p class="form-control-static">
-      <% if f.object.structured? %>
-        <%= _('Structured') %>
-      <% else %>
-        <%= _('Classic') %>
-      <% end %>
-    </p>
+  <%= f.hidden_field :type, id: nil %>
+  <p class="form-control-static">
+    <% if f.object.structured? %>
+      <%= _('Structured') %>
+    <% elsif f.object.module? %>
+      <%= _('Module') %>
+    <% else %>
+      <%= _('Classic') %>
+    <% end %>
+  </p>
 </div>
 
 <div class="form-group col-xs-8">
@@ -56,6 +59,7 @@
           [["Research Project", "research_project"], ["Research Entity", "research_entity"]],
           f.object.context
         ),
+        disabled: f.object.module?,
         class: "form-control",
         name: 'template[context]') %>
   <% else %>
@@ -68,6 +72,29 @@
     </p>
   <% end %>
 </div>
+
+<% if f.object.module? %>
+  <div class="form-group col-xs-8">
+    <%= f.label(:data_type, _('Data type'), class: "control-label") %>
+    <% if f.object.new_record? %>
+      <%= select_tag(:data_type,
+          options_for_select(
+            [[_("None"), "none"], [_("Software"), "software"]],
+            f.object.data_type
+          ),
+          class: "form-control",
+          name: 'template[data_type]') %>
+      <% else %>
+        <p class="form-control-static">
+          <% if f.object.data_type.eql?('software') %>
+            <%= _("Software") %>
+          <% else %>
+            <%= _("None") %>
+          <% end %>
+        </p>
+      <% end %>
+  </div>
+<% end %>
 
 <div class="form-group col-xs-8">
   <%= label_tag(:status, _('Status'), class: "control-label") %>

--- a/app/views/branded/org_admin/templates/_form.html.erb
+++ b/app/views/branded/org_admin/templates/_form.html.erb
@@ -39,24 +39,34 @@
 
 <div class="form-group col-xs-8">
   <%= f.label(:type, _('Type'), class: "control-label") %>
-  <%= select_tag(:type,
-      options_for_select(
-        [["Classic", "classic"], ["Structured", "structured"]],
-        f.object.type
-      ),
-      class: "form-control",
-      name: 'template[type]') %>
+    <p class="form-control-static">
+      <% if f.object.structured? %>
+        <%= _('Structured') %>
+      <% else %>
+        <%= _('Classic') %>
+      <% end %>
+    </p>
 </div>
 
 <div class="form-group col-xs-8">
   <%= f.label(:context, _('Context'), class: "control-label") %>
-  <%= select_tag(:context,
-      options_for_select(
-        [["Research Project", "research_project"], ["Research Entity", "research_entity"]],
-        f.object.context
-      ),
-      class: "form-control",
-      name: 'template[context]') %>
+  <% if f.object.new_record? %>
+    <%= select_tag(:context,
+        options_for_select(
+          [["Research Project", "research_project"], ["Research Entity", "research_entity"]],
+          f.object.context
+        ),
+        class: "form-control",
+        name: 'template[context]') %>
+  <% else %>
+    <p class="form-control-static">
+      <% if f.object.research_entity? %>
+        <%= _('Research Entity') %>
+      <% else %>
+        <%= _('Research Project') %>
+      <% end %>
+    </p>
+  <% end %>
 </div>
 
 <div class="form-group col-xs-8">

--- a/app/views/branded/org_admin/templates/_navigation.html.erb
+++ b/app/views/branded/org_admin/templates/_navigation.html.erb
@@ -1,0 +1,17 @@
+<ul class="nav nav-tabs" role="tablist">
+  <li role="presentation" <%= active_page?(template_details_path(template), true) ? ' class=active' : '' %>>
+    <%= link_to(_('Template details'), template_details_path(template), { 'aria-controls': 'show_template', role: 'tab' }) %>
+  </li>
+  <% template.phases.each do |phase| %><%# TODO when phase is modifiable and show is accessed, it does not get active tab %>
+    <% phase_path = (modifiable && !template.customization_of.present?) ? edit_org_admin_template_phase_path(template.id, phase.id) : org_admin_template_phase_path(template.id, phase.id) %>
+    <li role="presentation" <%= active_page?(phase_path) ? ' class=active' : '' %>>
+      <%= link_to(phase.title, phase_path, { 'aria-controls': "#{phase.id}", role: 'tab' }) %>
+    </li>
+  <% end %>
+  <!-- Add another phase button -->
+  <% if template_modifiable?(template) && can_add_phase?(template) %>
+    <li role="presentation" <%= active_page?(new_org_admin_template_phase_path(template.id)) ? ' class=active' : '' %>>
+      <%= link_to(_('Add new phase'), new_org_admin_template_phase_path(template.id), { 'aria-controls': 'add_phase', role: 'tab' }) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/branded/org_admin/templates/index.html.erb
+++ b/app/views/branded/org_admin/templates/index.html.erb
@@ -117,6 +117,11 @@
     <a href="<%= new_org_admin_template_path(type: "structured") %>" class="btn btn-primary" role="button">
       <%= _('Create a template') %>
     </a>
+    <% if current_user.can_super_admin? %>
+      <a href="<%= new_org_admin_template_path(type: "module") %>" class="btn btn-primary" role="button">
+        <%= _('Create a module template') %>
+      </a>
+    <% end %>
     <a href="<%= new_org_admin_template_path(type: "classic") %>">
       <%= _('Create a classic template') %>
     </a>

--- a/app/views/branded/org_admin/templates/index.html.erb
+++ b/app/views/branded/org_admin/templates/index.html.erb
@@ -1,0 +1,124 @@
+<% title 'Templates' %>
+<div class="row">
+  <div class="col-md-12">
+    <h1><%= _('Templates') %></h1>
+  </div>
+
+  <% if current_user.can_super_admin? %>
+    <div class="col-md-12">
+      <p>
+        <%= _('If you would like to modify one of the templates below, you must first change your organisation affiliation.') %>
+      </p>
+    </div>
+    <div class="col-md-6">
+      <%= form_for current_user, url: user_org_swaps_path(current_user),
+                                 namespace: 'superadmin',
+                                 method: "post",
+                                 html: { id: 'super-admin-switch-org' } do |f| %>
+        <%= render partial: "shared/org_selectors/local_only",
+                      locals: {
+                        form: f,
+                        default_org: current_user.org,
+                        orgs: @orgs,
+                        required: false
+                      } %>
+        <%= f.submit _('Change affiliation'), class: 'btn btn-default' %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="col-md-12">
+    <p>
+      <%= _('If you wish to add an organisational template for a Data Management Plan, use the \'create template\' button. You can create more than one template if desired e.g. one for researchers and one for PhD students. Your template will be presented to users within your organisation when no funder templates apply. If you want to add questions to funder templates use the \'customise template\' options below.') %>
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <ul class="nav nav-tabs" role="tablist">
+
+      <% if current_user.can_super_admin? %>
+        <li role="presentation" class="<%= action_name == 'index' ? 'active' : '' %>">
+          <%= link_to(_('All Templates'), org_admin_templates_path, { role: 'tab' }) %>
+        </li>
+      <% end %>
+
+      <li role="presentation"
+          class="<%= action_name == 'organisational' ? 'active' : '' %>">
+
+        <%= link_to(organisational_org_admin_templates_path, { role: 'tab' }) do %>
+          <% if current_user.can_super_admin? %>
+            <% _('%{org_name} Templates') % { org_name: current_user.org.name } %>
+          <% else %>
+            <% _('Own Templates') %>
+          <% end %>
+        <% end %>
+
+      </li>
+
+      <% if !current_user.org.funder_only? %>
+        <li role="presentation"
+            class="<%= action_name == 'customisable' ? 'active' : '' %>">
+          <%= link_to(_('Customisable Templates'),
+              customisable_org_admin_templates_path, { role: 'tab' }) %>
+        </li>
+      <% end %>
+    </ul>
+
+    <div class="tab-content">
+      <div role="tabpanel" class="tab-pane active">
+        <div class="panel panel-default">
+          <div class="panel-body template-scope">
+            <h2><%= @title %></h2>
+            <div class="template-table-filters">
+              <% filter_path = "/paginable/templates/#{action_name}/#{1}" %>
+              <% qry = @query_params.collect{ |k,v| "#{k}=#{v}" }.join('&') %>
+              <ul class="nav navbar-nav">
+                <% if action_name == 'customisable' %>
+                  <li>
+                    <%= link_to _('All (%{count})') % { count: @all_count}, "#{filter_path}?#{qry}", 'data-remote': "true" %>
+                  </li>
+                  <li>
+                    <%= link_to _('Published (%{count})') % { count: @published_count}, "#{filter_path}?f=published&#{qry}", 'data-remote': "true" %>
+                  </li>
+                  <li>
+                    <%= link_to _('Unpublished (%{count})') % { count: @unpublished_count}, "#{filter_path}?f=unpublished&#{qry}", 'data-remote': "true" %>
+                  </li>
+                  <li>
+                    <%= link_to _('Not customised (%{count})') % { count: @not_customized_count}, "#{filter_path}?f=not-customised&#{qry}", 'data-remote': "true" %>
+                  </li>
+                <% else %>
+                  <li>
+                    <%= link_to _('All (%{count})') % { count: @all_count}, "#{filter_path}?#{qry}", 'data-remote': "true" %>
+                  </li>
+                  <li>
+                    <%= link_to _('Published (%{count})') % { count: @published_count}, "#{filter_path}?f=published&#{qry}", 'data-remote': "true" %>
+                  </li>
+                  <li>
+                    <%= link_to _('Unpublished (%{count})') % { count: @unpublished_count}, "#{filter_path}?f=unpublished&#{qry}", 'data-remote': "true" %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+            <%= paginable_renderise(
+                  partial: "paginable/templates/#{action_name}",
+                  controller: 'paginable/templates',
+                  action: action_name,
+                  remote: true,
+                  scope: @templates,
+                  query_params: @query_params,
+                  locals: { customizations: @customizations }) %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <a href="<%= new_org_admin_template_path(type: "structured") %>" class="btn btn-primary" role="button">
+      <%= _('Create a template') %>
+    </a>
+    <a href="<%= new_org_admin_template_path(type: "classic") %>">
+      <%= _('Create a classic template') %>
+    </a>
+  </div>
+</div>

--- a/db/madmp_seeds.rb
+++ b/db/madmp_seeds.rb
@@ -14,7 +14,7 @@ question_formats = [
     title: "Structured",
     description: "Structured",
     option_based: false,
-    formattype: 7,
+    formattype: 9,
     structured: true
   }
 ]

--- a/db/migrate/20240423135855_add_data_type_to_templates.rb
+++ b/db/migrate/20240423135855_add_data_type_to_templates.rb
@@ -1,0 +1,5 @@
+class AddDataTypeToTemplates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :templates, :data_type, :string, null: false, default: 'none'
+  end
+end

--- a/db/migrate/20240423141629_add_data_type_to_madmp_schemas.rb
+++ b/db/migrate/20240423141629_add_data_type_to_madmp_schemas.rb
@@ -1,0 +1,5 @@
+class AddDataTypeToMadmpSchemas < ActiveRecord::Migration[7.1]
+  def change
+    add_column :madmp_schemas, :data_type, :string, null: false, default: 'none'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_09_135011) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_23_141629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "annotations", id: :serial, force: :cascade do |t|
     t.integer "question_id"
@@ -225,6 +226,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_09_135011) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "api_client_id"
+    t.string "data_type", default: "none", null: false
     t.index ["api_client_id"], name: "index_madmp_schemas_on_api_client_id"
     t.index ["org_id"], name: "index_madmp_schemas_on_org_id"
   end
@@ -593,6 +595,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_09_135011) do
     t.integer "type", default: 0, null: false
     t.integer "context", default: 0, null: false
     t.boolean "is_recommended", default: false
+    t.string "data_type", default: "none", null: false
     t.index ["customization_of", "version", "org_id"], name: "templates_customization_of_version_org_id_key", unique: true
     t.index ["family_id", "version"], name: "templates_family_id_version_key", unique: true
     t.index ["org_id"], name: "templates_org_id_idx"

--- a/engines/madmp_opidor/app/controllers/super_admin/madmp_schemas_controller.rb
+++ b/engines/madmp_opidor/app/controllers/super_admin/madmp_schemas_controller.rb
@@ -82,7 +82,7 @@ module SuperAdmin
     end
 
     def permitted_params
-      params.require(:madmp_schema).permit(:label, :name, :version, :classname, :api_client_id, :schema)
+      params.require(:madmp_schema).permit(:label, :name, :version, :classname, :api_client_id, :schema, :data_type)
     end
   end
 end

--- a/engines/madmp_opidor/app/views/super_admin/madmp_schemas/_form.html.erb
+++ b/engines/madmp_opidor/app/views/super_admin/madmp_schemas/_form.html.erb
@@ -13,6 +13,15 @@
       <div class="form-group">
         <%= f.label(:name, _('Classname'), class: 'control-label') %>
         <%= f.text_field(:classname, class: "form-control", spellcheck: true, "aria-required": true) %>
+      <div class="form-group">
+        <%= f.label(:data_type, _('Data type'), class: 'control-label') %>
+        <%= select_tag(:data_type,
+            options_for_select(
+              [[_("None"), "none"], [_("Software"), "software"]],
+              f.object.data_type
+            ),
+            class: "form-control",
+            name: 'madmp_schema[data_type]') %>
       </div>
       <div class="form-group">
         <%= f.label(:version, _('Version'), class: 'control-label') %>


### PR DESCRIPTION
### Modification de la création/ajout des modèles de DMP

- Le bouton Créer un modèle permet de créer un modèle structuré
- Ajout d'un bouton Créer un modèle classique
- Le type de modèle n'est plus modifiable
- Le contexte du modèle n'est plus modifiable après sa création
- Les modèles structurés ne peuvent désormais avoir qu'une seule phase

### Ajout d'un nouveau type de modèle de DMP, appelé Module.

Un module est un modèle ne comportant qu'une phase. On ne peut pas créer de plan à partir d'un module mais un plan peut utiliser les sections et les questions du module en fonction des paramètres d'un de ses produits de recherche.

- Ajout d'un champ data_type permettant de définir le type de produit de recherche utilisant ce module.
- Ajout du champ data_type à madmp_schemas
- On ne peut pas créer de phase (une seule présente)
- L'ajout de questions et de sections est identique à l'existant
- Les formulaires proposés dans l'ajout d'une question sont ceux qui concernent le data_type du modèle.